### PR TITLE
Use helicity for MCParticles once it becomes available

### DIFF
--- a/SimG4Components/src/SimG4SmearGenParticles.cpp
+++ b/SimG4Components/src/SimG4SmearGenParticles.cpp
@@ -8,6 +8,7 @@
 #include "G4Event.hh"
 
 // datamodel
+#include "edm4hep/EDM4hepVersion.h"
 #include "edm4hep/MCParticleCollection.h"
 
 // DD4hep
@@ -55,7 +56,11 @@ StatusCode SimG4SmearGenParticles::execute(const EventContext&) const {
       particle.setTime(j.getTime());
       particle.setSimulatorStatus(j.getSimulatorStatus());
       particle.setMomentumAtEndpoint(j.getMomentumAtEndpoint());
+#if EDM4HEP_BUILD_VERSION <= EDM4HEP_VERSION(0, 99, 2)
       particle.setSpin(j.getSpin());
+#else
+      particle.setHelicity(j.getHelicity());
+#endif
       particle.setVertex(j.getVertex());
 
       // smear momentum according to trackers resolution


### PR DESCRIPTION

BEGINRELEASENOTES
- Switch to using `helicity` instead of `spin` once it becomes available. See [EDM4hep#404](https://github.com/key4hep/EDM4hep/pull/404) for more details

ENDRELEASENOTES
