### PR TITLE
Fix shadowing warnings with Clang

### DIFF
--- a/SimG4Common/include/SimG4Common/Units.h
+++ b/SimG4Common/include/SimG4Common/Units.h
@@ -1,8 +1,7 @@
 #ifndef SIMG4COMMON_UNITS_H
 #define SIMG4COMMON_UNITS_H
 
-// Geant4
-#include "G4SystemOfUnits.hh"
+#include "CLHEP/Units/SystemOfUnits.h"
 
 /** Conversion between units.
  *

--- a/SimG4Common/src/EventInformation.cpp
+++ b/SimG4Common/src/EventInformation.cpp
@@ -2,9 +2,9 @@
 
 #include "G4Track.hh"
 
-#include "SimG4Common/Units.h"
-
 #include "edm4hep/MCParticleCollection.h"
+
+#include "SimG4Common/Units.h"
 
 namespace sim {
 EventInformation::EventInformation() { m_mcParticles = new edm4hep::MCParticleCollection(); }

--- a/SimG4Components/src/SimG4GeantinosFromEdmTool.cpp
+++ b/SimG4Components/src/SimG4GeantinosFromEdmTool.cpp
@@ -1,17 +1,12 @@
-// local
 #include "SimG4GeantinosFromEdmTool.h"
 
-// Gaudi
 #include "GaudiKernel/PhysicalConstants.h"
 
-// FCCSW
+#include "edm4hep/MCParticleCollection.h"
+
 #include "SimG4Common/ParticleInformation.h"
 #include "SimG4Common/Units.h"
 
-// datamodel
-#include "edm4hep/MCParticleCollection.h"
-
-// Geant4
 #include "G4Event.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTable.hh"

--- a/SimG4Components/src/SimG4PrimariesFromEdmTool.cpp
+++ b/SimG4Components/src/SimG4PrimariesFromEdmTool.cpp
@@ -1,17 +1,12 @@
-// local
 #include "SimG4PrimariesFromEdmTool.h"
 
-// Gaudi
 #include "GaudiKernel/PhysicalConstants.h"
 
-// FCCSW
+#include "edm4hep/MCParticleCollection.h"
+
 #include "SimG4Common/ParticleInformation.h"
 #include "SimG4Common/Units.h"
 
-// datamodel
-#include "edm4hep/MCParticleCollection.h"
-
-// Geant4
 #include "G4Event.hh"
 
 // Declaration of the Tool

--- a/SimG4Components/src/SimG4PrimariesFromEdmTool.h
+++ b/SimG4Components/src/SimG4PrimariesFromEdmTool.h
@@ -1,7 +1,6 @@
 #ifndef SIMG4COMPONENTS_G4PRIMARIESFROMEDMTOOL_H
 #define SIMG4COMPONENTS_G4PRIMARIESFROMEDMTOOL_H
 
-// from Gaudi
 #include "GaudiKernel/AlgTool.h"
 #include "k4FWCore/DataHandle.h"
 

--- a/SimG4Components/src/SimG4SaveParticleHistory.cpp
+++ b/SimG4Components/src/SimG4SaveParticleHistory.cpp
@@ -1,16 +1,7 @@
 #include "SimG4SaveParticleHistory.h"
 
-// FCCSW
-#include "SimG4Common/ParticleInformation.h"
-#include "SimG4Common/Units.h"
-
-// Geant4
 #include "G4Event.hh"
-#include "G4EventManager.hh"
-#include "G4PrimaryParticle.hh"
-#include "G4PrimaryVertex.hh"
 
-// datamodel
 #include "edm4hep/MCParticleCollection.h"
 
 DECLARE_COMPONENT(SimG4SaveParticleHistory)

--- a/SimG4Components/src/SimG4SaveParticleHistory.h
+++ b/SimG4Components/src/SimG4SaveParticleHistory.h
@@ -1,10 +1,8 @@
 #ifndef SIMG4COMPONENTS_SIMG4SAVEPARTICLEHISTORY_H
 #define SIMG4COMPONENTS_SIMG4SAVEPARTICLEHISTORY_H
 
-// Gaudi
 #include "GaudiKernel/AlgTool.h"
 
-// FCCSW
 #include "SimG4Common/EventInformation.h"
 #include "SimG4Interface/ISimG4SaveOutputTool.h"
 #include "k4FWCore/DataHandle.h"

--- a/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
+++ b/SimG4Components/src/SimG4SingleParticleGeneratorTool.cpp
@@ -1,22 +1,17 @@
-// local
 #include "SimG4SingleParticleGeneratorTool.h"
 
-// FCCSW
 #include "SimG4Common/Units.h"
 
-// Gaudi
 #include "GaudiKernel/PhysicalConstants.h"
 
-// CLHEP
+#include "edm4hep/MCParticleCollection.h"
+
 #include <CLHEP/Random/RandFlat.h>
 
-// Geant4
 #include "G4Event.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTable.hh"
 
-// datamodel
-#include "edm4hep/MCParticleCollection.h"
 
 // Declaration of the Tool
 DECLARE_COMPONENT(SimG4SingleParticleGeneratorTool)

--- a/SimG4Components/src/SimG4SingleParticleGeneratorTool.h
+++ b/SimG4Components/src/SimG4SingleParticleGeneratorTool.h
@@ -1,25 +1,19 @@
 #ifndef SIMG4COMPONENTS_G4SINGLEPARTICLEGENERATORTOOL_H
 #define SIMG4COMPONENTS_G4SINGLEPARTICLEGENERATORTOOL_H
 
-// Gaudi
 #include "GaudiKernel/AlgTool.h"
 
-// FCCSW
 #include "SimG4Interface/ISimG4EventProviderTool.h"
 #include "k4FWCore/DataHandle.h"
 
-// Geant4
-#include "G4SystemOfUnits.hh"
+#include <edm4hep/MCParticleCollection.h>
+#include <CLHEP/Units/SystemOfUnits.h>
 
 // Forward declarations
 // Geant4
 class G4Event;
 class G4PrimaryVertex;
 class G4PrimaryParticle;
-// datamodel
-namespace edm4hep {
-class MCParticleCollection;
-}
 
 /** @class SimG4SingleParticleGeneratorTool SimG4SingleParticleGeneratorTool.h "SimG4SingleParticleGeneratorTool.h"
  *

--- a/SimG4Components/src/SimG4SmearGenParticles.cpp
+++ b/SimG4Components/src/SimG4SmearGenParticles.cpp
@@ -1,17 +1,7 @@
 #include "SimG4SmearGenParticles.h"
 
-// FCCSW
-#include "SimG4Common/ParticleInformation.h"
-#include "SimG4Common/Units.h"
-
-// Geant4
-#include "G4Event.hh"
-
-// datamodel
-#include "edm4hep/MCParticleCollection.h"
-
-// DD4hep
-#include "DD4hep/Segmentations.h"
+#include <edm4hep/MCParticleCollection.h>
+#include <CLHEP/Vector/ThreeVector.h>
 
 DECLARE_COMPONENT(SimG4SmearGenParticles)
 

--- a/SimG4Components/src/SimG4SmearGenParticles.h
+++ b/SimG4Components/src/SimG4SmearGenParticles.h
@@ -7,7 +7,6 @@
 
 // FCCSW
 #include "SimG4Interface/ISimG4ParticleSmearTool.h"
-#include "SimG4Interface/ISimG4SaveOutputTool.h"
 #include "k4FWCore/DataHandle.h"
 
 // datamodel


### PR DESCRIPTION
BEGINRELEASENOTES
- Cleanup and change include ordering to about shadowing warnings that happen because CLHEP defines single letter variables in the global namespace.

ENDRELEASENOTES

The warnings look like:

```
In file included from /k4SimGeant4/SimG4Components/src/SimG4SmearGenParticles.cpp:11:
In file included from /EDM4HEP/edm4hep/edm4hep/MCParticleCollection.h:15:
In file included from /podio/include/podio/detail/Pythonizations.h:5:
In file included from /usr/include/python3.13/Python.h:72:
In file included from /usr/include/python3.13/lock.h:9:
/usr/include/python3.13/cpython/lock.h:56:26: warning: declaration shadows a variable in namespace 'CLHEP' [-Wshadow]
   56 | _PyMutex_Unlock(PyMutex *m)
      |                          ^
/usr/include/CLHEP/Units/SystemOfUnits.h:113:27: note: previous declaration is here
  113 |   static constexpr double m  = meter;
```

Since it's CLHEP the one defining the variables it's enough to put the edm4hep includes before