### PR TITLE
Fix possible use of uninitialized variable.

### DIFF
--- a/SimG4Components/src/SimG4MagneticFieldFromMapTool.cpp
+++ b/SimG4Components/src/SimG4MagneticFieldFromMapTool.cpp
@@ -251,7 +251,7 @@ StatusCode SimG4MagneticFieldFromMapTool::loadComsolMap() {
 
   std::string inLine;
   size_t nLines = 0;
-  size_t nLinesExpected;
+  size_t nLinesExpected = 0;
   std::vector<double> fieldPositionR;
   std::vector<double> fieldPositionZ;
   std::vector<double> fieldComponentR;


### PR DESCRIPTION
Fixes warning seen when compiling with gcc15.


BEGINRELEASENOTES
-  Fix a gcc15 warning about a possible use of an uninitialized variable.
ENDRELEASENOTES
